### PR TITLE
Implemented lektorek Polish dictionary

### DIFF
--- a/docs/german.txt
+++ b/docs/german.txt
@@ -1,0 +1,3 @@
+Zu den zentralen Aufgabengebieten der Phonologie gehört das Ermitteln von sogenannten distinktiven Merkmalen sowie den Phoneminventaren und Silben­strukturen unterschiedlicher Lautsprachen. Als Begründer der Phonologie in Europa gelten die Russen Nikolai Sergejewitsch Trubetzkoy, Ethnologe und Linguist, und der Strukturalist Roman Jakobson.
+
+Phonologie hat eine Vielzahl alternativer Namen; Metzlers Lexikon der Sprache nennt: funktionelle Phonetik, funktionale Phonetik, Phonematik, Phonemik, Phonemtheorie, Sprachgebildelautlehre. Dabei ist Phonemik wegen des gewünschten Parallelismus zu Phonetik noch relativ verbreitet. Allerdings gibt es für Phonemik und Phonematik auch eine Vielzahl abweichender Begriffsbildungen.

--- a/gui.html
+++ b/gui.html
@@ -8,6 +8,18 @@
         height: 100%;
       }
 
+      .bold{
+        font-weight: bold;
+      }
+
+      .italics{
+        font-style: italic;
+      }
+
+      .non_current{
+        color: silver;
+      }
+
       #wordrefcontainer {
         height: 1000px;
       }
@@ -92,7 +104,7 @@
           </span>
           <span class="btn btn-lg btn-secondary">
           <label for="source_dict">Dictionary:</label>
-          <select id="source_dict" name="source_dict" onchange="setSourceDictFunction(event);">
+          <select id="source_dict" name="source_dict" onchange="setSourceDictFunction(event); clearJsonDict();">
             <optgroup label="Italian">
               <option value="wordref_iten">wordreference Italian - English</option>
               <option value="wordref_definition">wordreference Italian Definition</option>
@@ -114,6 +126,7 @@
         <div class="col-md-6">
           <div id="reference" data-spy="affix" data-offset-top="200" data-offset-bottom="200">
             <div id="wordrefcontainer" class="embed-responsive embed-responsive-16by9">
+            <div id="jsondict"></div>
               <iframe id="wordref" class="embed-responsive-item" src=""></iframe>
             </div>
           </div>
@@ -130,6 +143,10 @@
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
     <script>
 
+      function clearJsonDict() {
+        document.getElementById("jsondict").innerHTML = "";
+      }
+
       function loadWordrefItEn(word) {
         document.getElementById("wordref").src = "http://www.wordreference.com/iten/" + word;
       }
@@ -140,14 +157,33 @@
 
       function loadLektorek(word) {
         var api_url = "http://lektorek.org/dapi/v1/index.php/search/chomper/polish/" + word + "?diacritics=true&pos=all";
-        var iframeElement = document.getElementById("wordref");
-        iframeElement.src = "http://lektorek.org/polish/";
-        iframeElement.addEventListener("load", function(event) {
-          var iframeDocumentElement = document.getElementById('wordref').contentWindow.document;
-          iframeDocumentElement.getElementById("searchStringId").value = "word";
-          iframeDocumentElement.querySelectorAll("input[value=Search]").click();
-        });
-        console.log(api_url);
+
+        function reqListener () {
+          var jsonDictElement = document.getElementById("jsondict");
+          var jsonString = this.responseText;
+          var json = JSON.parse(jsonString);
+          var results = json.results;
+          var resultsText = results.map(function (obj) {
+            return obj.embedded_definition;
+          });
+          var temp_div = document.createElement("div");
+          temp_div.innerHTML = resultsText.join('<br><br>') + '<br><br>';
+          if (jsonDictElement.childNodes[0]) {jsonDictElement.childNodes[0].className = "non_current";}
+          jsonDictElement.insertBefore(temp_div, jsonDictElement.firstElementChild);
+        }
+
+        var oReq = new XMLHttpRequest();
+        oReq.addEventListener("load", reqListener);
+        oReq.open("GET", api_url);
+        oReq.send();
+
+//        var iframeElement = document.getElementById("wordref");
+//        iframeElement.src = "http://lektorek.org/polish/";
+//        iframeElement.addEventListener("load", function(event) {
+//          var iframeDocumentElement = document.getElementById('wordref').contentWindow.document;
+//          iframeDocumentElement.getElementById("searchStringId").value = "word";
+//          iframeDocumentElement.querySelectorAll("input[value=Search]").click();
+//        });
       }
 
       function loadWordrefPlEn(word) {

--- a/gui.html
+++ b/gui.html
@@ -104,7 +104,7 @@
           </span>
           <span class="btn btn-lg btn-secondary">
           <label for="source_dict">Dictionary:</label>
-          <select id="source_dict" name="source_dict" onchange="setSourceDictFunction(event); clearJsonDict();">
+          <select id="source_dict" name="source_dict" onchange="setSourceDictFunction(event); clearElements();">
             <optgroup label="Italian">
               <option value="wordref_iten">wordreference Italian - English</option>
               <option value="wordref_definition">wordreference Italian Definition</option>
@@ -143,8 +143,9 @@
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
     <script>
 
-      function clearJsonDict() {
+      function clearElements() {
         document.getElementById("jsondict").innerHTML = "";
+        document.getElementById("wordref").src = "";
       }
 
       function loadWordrefItEn(word) {

--- a/gui.html
+++ b/gui.html
@@ -109,6 +109,10 @@
               <option value="wordref_iten">wordreference Italian - English</option>
               <option value="wordref_definition">wordreference Italian Definition</option>
             </optgroup>
+            <optgroup label="German">
+              <option value="wordref_deen">wordreference German - English</option>
+              <option value="dict_cc">dict.cc</option>              
+            </optgroup>
             <optgroup label="Polish">
               <option value="lektorek">lektorek</option>
               <option value="wordref_plen">wordreference Polish - English</option>
@@ -156,6 +160,14 @@
         document.getElementById("wordref").src = "http://www.wordreference.com/definizione/" + word;
       }
 
+      function loadWordrefDeEn(word) {
+        document.getElementById("wordref").src = "http://www.wordreference.com/deen/" + word;
+      }
+
+      function loadDictCC(word) {
+        document.getElementById("wordref").src = "http://www.dict.cc/?s=" + word;
+      }
+
       function loadLektorek(word) {
         var api_url = "http://lektorek.org/dapi/v1/index.php/search/chomper/polish/" + word + "?diacritics=true&pos=all";
 
@@ -200,6 +212,12 @@
             break;
           case "wordref_definition":
             sourceDictFunction = loadWordrefDefinition;
+            break;
+          case "wordref_deen":
+            sourceDictFunction = loadWordrefDeEn;
+            break;
+          case "dict_cc":
+            sourceDictFunction = loadDictCC;
             break;
           case "lektorek":
             sourceDictFunction = loadLektorek;


### PR DESCRIPTION
Added support for Lektorek Polish dictionary. This requires Chrome to
be in a mode with CORS disabled - I use CORS toggle add-on for Chrome.
I'm pulling json data from the lektorek api from which I then display
the 'embedded_definition' (this already has html markup for bold and
italic classes which I added to the css. I've styled it so that as new
searches are made by clicking, the new result is added as a new DIV at
the start of the list of DIVs with previous searches moving down and
getting gray text through a CSS class.
